### PR TITLE
Optionally dump intermediate files to a specified directory.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,9 @@
-# Below is a list of people and organizations that have contributed
-# to the project.  Names should be added to the list like so:
-#
-#   Name/Organization <email address>
+# This is the official list of authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
 
-Ben Smith <binji@chromium.org>
+# Names should be added to this file as:
+# Name or Organization <email address>
+# The email address is not required for organizations.
+
+Google Inc.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,13 @@
+# People who have agreed to one of the CLAs and can contribute patches.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# https://developers.google.com/open-source/cla/individual
+# https://developers.google.com/open-source/cla/corporate
+#
+# Names should be added to this file as:
+#     Name <email address>
+
+Ben Smith <binji@chromium.org>
+Nick Bray <ncbray@chromium.org>

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import os.path
 import shutil
 import subprocess
 import sys
@@ -25,16 +26,24 @@ def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('c_file', help='test C file')
   parser.add_argument('js_file', help='test JS file')
+  parser.add_argument('--dump', help='directory to store intermediate files')
   options = parser.parse_args(args)
 
   basename = os.path.splitext(os.path.basename(options.c_file))[0]
-  temp_dir = tempfile.mkdtemp(prefix='wasm-e2e-run-')
+  if not options.dump:
+    clean_temp_dir = True
+    temp_dir = tempfile.mkdtemp(prefix='wasm-e2e-run-')
+  else:
+    clean_temp_dir = False
+    temp_dir = options.dump
+    if not os.path.exists(temp_dir):
+      os.makedirs(temp_dir)
   wack_file = os.path.join(temp_dir, basename + '.wack')
   wast_file = os.path.join(temp_dir, basename + '.wast')
   wasm_file = os.path.join(temp_dir, basename + '.wasm')
 
   try:
-    subprocess.check_call([WACC, options.c_file, '-o', wack_file])
+    subprocess.check_call([WACC, '-fno-builtin', options.c_file, '-o', wack_file])
     subprocess.check_call([sys.executable, WASMATE, wack_file, '-o', wast_file])
     subprocess.check_call([SEXPR_WASM, '--br-if', wast_file, '-o', wasm_file])
     process = subprocess.Popen([D8, options.js_file, '--', wasm_file],
@@ -43,7 +52,8 @@ def main(args):
     if process.returncode != 0:
       raise Error(stderr)
   finally:
-    shutil.rmtree(temp_dir)
+    if clean_temp_dir:
+      shutil.rmtree(temp_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also pass -fno-builtin to clang to avoid choking on infered memsets.
